### PR TITLE
Include collateralToken address

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -18,5 +18,5 @@
     "port": "5001"
   },
   "gasPrice": "1000000000",
-  "collateralToken": ""
+  "collateralToken": "0xd19bce9f7693598a9fa1f94c548b20887a33f141"
 }


### PR DESCRIPTION
I would recommend that we include the collateralToken address on the example we download. This reduces an extra step when users clone the repo to test.